### PR TITLE
allow fractional quota values in set subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v1.2.1 (TBD)
+# v1.3.0 (2019-01-07)
+
+New features:
+- Display quota bursting information when `--long` output flag is given.
+- Allow fractional quota values for the `set` subcommand.
 
 Changes:
 - Optimize library dependencies. Binary size has been reduced by over 20%.
@@ -6,10 +10,12 @@ Changes:
 # v1.2.0 (2018-11-05)
 
 New features:
-- Users can manually overwrite the OpenStack environment variables by providing them as command-line flags.
+- Users can manually overwrite the OpenStack environment variables by providing
+  them as command-line flags.
 
 Changes:
-- For the `--cluster` flag, the domain/project must be identified by ID. Specifiying a domain/project name will not work.
+- For the `--cluster` flag, the domain/project must be identified by ID.
+  Specifiying a domain/project name will not work.
 
 Bugfixes:
 - `--cluster` flag now works as expected.
@@ -18,8 +24,10 @@ Bugfixes:
 # v1.1.0 (2018-10-29)
 
 New features:
-- Human friendly values: users can give the `--human-readable` flag to get the different quota/usage values in a more human friendly unit. Only valid for
-	table/CSV output and can be combined with other output flags: `--names` or `--long`.
+- Human friendly values: users can give the `--human-readable` flag to get the
+  different quota/usage values in a more human friendly unit. Only valid for
+  table/CSV output and can be combined with other output flags: `--names` or
+  `--long`.
 
 
 # v1.0.0 (2018-10-24)

--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sapcc/gophercloud-limes/resources/v1/clusters"
 	"github.com/sapcc/gophercloud-limes/resources/v1/domains"
 	"github.com/sapcc/gophercloud-limes/resources/v1/projects"
-	"github.com/sapcc/limes"
 	"github.com/sapcc/limesctl/pkg/errors"
 )
 
@@ -127,18 +126,6 @@ func RunListTask(t ListTask, outputFmt string) {
 		t.renderCSV().writeTable(os.Stdout)
 	}
 }
-
-// Resource contains quota information about a single resource.
-type Resource struct {
-	Name    string
-	Value   int64
-	Unit    limes.Unit
-	Comment string
-}
-
-// Quotas is a map of service name to a list of resources. It contains the aggregate
-// quota values used by the set methods to update a single cluster/domain/project.
-type Quotas map[string][]Resource
 
 // SetTask is the interface type that abstracts a put operation.
 type SetTask interface {

--- a/pkg/cli/render_csv.go
+++ b/pkg/cli/render_csv.go
@@ -316,17 +316,6 @@ func timestampToString(timestamp *int64) string {
 type rawValues map[string]uint64
 type convertedValues map[string]string
 
-// unitExp is map of limes.Unit to x, such that base-2 exponential of x
-// is the number of bytes for some specific unit.
-var unitExp = map[limes.Unit]float64{
-	limes.UnitKibibytes: 10,
-	limes.UnitMebibytes: 20,
-	limes.UnitGibibytes: 30,
-	limes.UnitTebibytes: 40,
-	limes.UnitPebibytes: 50,
-	limes.UnitExbibytes: 60,
-}
-
 func humanReadable(convert bool, unit limes.Unit, rv rawValues) (string, convertedValues) {
 	cv := make(convertedValues, len(rv))
 
@@ -348,7 +337,7 @@ func humanReadable(convert bool, unit limes.Unit, rv rawValues) (string, convert
 		return string(unit), cv
 	}
 
-	oldExp := unitExp[unit]
+	oldExp := quotaUnits[unit]
 	usage := computeAgainst
 
 	var diffInExp float64
@@ -363,7 +352,7 @@ func humanReadable(convert bool, unit limes.Unit, rv rawValues) (string, convert
 
 	// determine the new unit
 	var newUnit limes.Unit
-	for k, v := range unitExp {
+	for k, v := range quotaUnits {
 		if v == (oldExp + diffInExp) {
 			newUnit = k
 		}


### PR DESCRIPTION
**Do not Merge**

Fixes #6 

As Falk and I discussed before the holidays, support for fractional quota values for the `set` subcommand have been implemented such that the base units for some service/resource are retrieved by doing a `GET` request for that specific cluster/domain/project, then the fractional values given at the command line are converted to their respective base units.

I have commented out the tests for the time being because the code for the `ParseQuotas` now does an API request which requires OpenStack auth credentials.

I wanted to get your review on the code first and then I will see how to best implement the tests.

FYI @reimannf 