### PR TITLE
Fixed null pointer exception when trying to set quota on invalid service

### DIFF
--- a/internal/core/parse_quotas.go
+++ b/internal/core/parse_quotas.go
@@ -194,9 +194,13 @@ func (c *Cluster) setBaseUnits(limesV1 *gophercloud.ServiceClient, ru *resourceU
 
 	for srv, resMap := range *ru {
 		for res := range resMap {
-			srvRes, exists := cluster.Services[srv].Resources[res]
-			if exists {
-				(*ru)[srv][res] = srvRes.ResourceInfo.Unit
+			if cluster.Services[srv] != nil {
+				srvRes, exists := cluster.Services[srv].Resources[res]
+				if exists {
+					(*ru)[srv][res] = srvRes.ResourceInfo.Unit
+				}
+			} else {
+				errors.Handle(fmt.Errorf("service %s for cluster %s could not be found", srv, cluster.ID), "")
 			}
 		}
 	}
@@ -218,9 +222,13 @@ func (d *Domain) setBaseUnits(limesV1 *gophercloud.ServiceClient, ru *resourceUn
 
 	for srv, resMap := range *ru {
 		for res := range resMap {
-			srvRes, exists := domain.Services[srv].Resources[res]
-			if exists {
-				(*ru)[srv][res] = srvRes.ResourceInfo.Unit
+			if domain.Services[srv] != nil {
+				srvRes, exists := domain.Services[srv].Resources[res]
+				if exists {
+					(*ru)[srv][res] = srvRes.ResourceInfo.Unit
+				}
+			} else {
+				errors.Handle(fmt.Errorf("service %s for domain %s could not be found", srv, domain.Name), "")
 			}
 		}
 	}
@@ -242,9 +250,13 @@ func (p *Project) setBaseUnits(limesV1 *gophercloud.ServiceClient, ru *resourceU
 
 	for srv, resMap := range *ru {
 		for res := range resMap {
-			srvRes, exists := project.Services[srv].Resources[res]
-			if exists {
-				(*ru)[srv][res] = srvRes.ResourceInfo.Unit
+			if project.Services[srv] != nil {
+				srvRes, exists := project.Services[srv].Resources[res]
+				if exists {
+					(*ru)[srv][res] = srvRes.ResourceInfo.Unit
+				}
+			} else {
+				errors.Handle(fmt.Errorf("service %s for project %s could not be found", srv, project.Name), "")
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue which occurs when you try to set quota on mistyped or non existing service. 

E.g.
```
limesctl project BLAH set coooompute/cores=10
```

Instead of running into a SIGSEGV the cli should panic with a corresponding error message.  

Fixes #14 