### PR TITLE
remove go-bits dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/sapcc/go-api-declarations v1.2.0
-	github.com/sapcc/go-bits v0.0.0-20220609133230-ebdc392bcda3
 	github.com/sapcc/gophercloud-sapcc v0.0.0-20220609133227-7782d10ec8cc
 )
 
@@ -17,6 +16,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,13 +28,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sapcc/go-api-declarations v1.2.0 h1:ypzrA7dc18VgtOLVaZnJ8vJ26T3ZFskr/2JLzgInd9s=
 github.com/sapcc/go-api-declarations v1.2.0/go.mod h1:zS+2xqmbtAyQxQz1liJp0qxDgop78fb4Sfk/IB0PvH0=
-github.com/sapcc/go-bits v0.0.0-20220609133230-ebdc392bcda3 h1:d/qMwd+T22KBXCLfWFx6OJUlDR7ShDRa7zDvyNI0xew=
-github.com/sapcc/go-bits v0.0.0-20220609133230-ebdc392bcda3/go.mod h1:lEiOyZpHHcoPhHltf80TunCTjvpv2u7z++XTEmufPgc=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20220609133227-7782d10ec8cc h1:Snk8/xTGzacq0wV0EkXFCufBN4cL6tNwKF91jsPC1dU=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20220609133227-7782d10ec8cc/go.mod h1:tM/aIwohLaPMcDaZb1LpNtZhiYiUFNGZtcuwui3naXI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/internal/cmd/parse_quotas.go
+++ b/internal/cmd/parse_quotas.go
@@ -22,12 +22,12 @@ package cmd
 import (
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/sapcc/go-api-declarations/limes"
-	"github.com/sapcc/go-bits/logg"
 
 	"github.com/sapcc/limesctl/v3/internal/core"
 )
@@ -118,7 +118,7 @@ func parseToQuotaRequest(resValues resourceQuotas, in []string) (limes.QuotaRequ
 		var newValWithUnit limes.ValueWithUnit
 		if isFloatVal || operation != "=" {
 			if isFloatVal {
-				logg.Info("Limes only accepts integer values, will attempt to convert %s %s to a suitable unit for %s/%s",
+				fmt.Fprintf(os.Stderr, "warning: Limes only accepts integer values, will attempt to convert %s %s to a suitable unit for %s/%s",
 					valStr, unit, service, resource)
 			}
 			var err error
@@ -127,7 +127,7 @@ func parseToQuotaRequest(resValues resourceQuotas, in []string) (limes.QuotaRequ
 				return nil, err
 			}
 			if isFloatVal {
-				logg.Info("%s %s -> %s", valStr, unit, newValWithUnit.String())
+				fmt.Fprintf(os.Stderr, "warning: converted %s %s -> %s", valStr, unit, newValWithUnit.String())
 			}
 		} else {
 			v, err := strconv.ParseUint(valStr, 10, 64)


### PR DESCRIPTION
Two logg.Info() calls for a corner case don't really justify pulling in this entire library in my opinion, esp. because this dependency generates quite some additional noise from Renovate Bot.