### PR TITLE
replace password cmd with go-bits implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gophercloud/utils v0.0.0-20231010081019-80377eca5d56
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sapcc/go-api-declarations v1.10.5
+	github.com/sapcc/go-bits v0.0.0-20231221010852-98deb05b5d97
 	github.com/sapcc/gophercloud-sapcc v0.0.0-20231221015832-0b675b20fad5
 	github.com/spf13/cobra v1.8.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gophercloud/utils v0.0.0-20231010081019-80377eca5d56
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sapcc/go-api-declarations v1.10.5
+	github.com/sapcc/go-bits v0.0.0-20231213211425-ddd5e41f8535
 	github.com/sapcc/gophercloud-sapcc v0.0.0-20231214091214-e4517ca1b6a4
 	github.com/spf13/cobra v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,12 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sapcc/go-api-declarations v1.10.5 h1:1jGXudH2kcS0JCfGqooHszhSIe7BCvqu7QYJdqfas0A=
 github.com/sapcc/go-api-declarations v1.10.5/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-bits v0.0.0-20231213211425-ddd5e41f8535 h1:spliyqfKEO+098p/TBNjNIhXoyCqj1Zf+pROsaoN9SQ=
+github.com/sapcc/go-bits v0.0.0-20231213211425-ddd5e41f8535/go.mod h1:jsn7K60WbjIzXz5V38eeHP2SNsBsCpFOtbXOSsBZXoQ=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20231214091214-e4517ca1b6a4 h1:bPzqErdlvFN8KkZorXj0Js2bIMrSAt5oGdo65ncjnSM=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20231214091214-e4517ca1b6a4/go.mod h1:W7BMHKOIhBMtBOqCDBT4APx7A48q7wt9i0jPB0PDXLs=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,12 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sapcc/go-api-declarations v1.10.5 h1:1jGXudH2kcS0JCfGqooHszhSIe7BCvqu7QYJdqfas0A=
 github.com/sapcc/go-api-declarations v1.10.5/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-bits v0.0.0-20231221010852-98deb05b5d97 h1:hUBB+owZ3eqoG5BiDmlHglUKjM9zLfz15m5Q8gb9gzA=
+github.com/sapcc/go-bits v0.0.0-20231221010852-98deb05b5d97/go.mod h1:wEFayuwafHrMvuG4rT7d4AV5BQiopTA4UndFP3CuwMI=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20231221015832-0b675b20fad5 h1:nkiG0DfhWFLLR6k+/ZM+77EGNw+qdMQHXJPCa9G+aVE=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20231221015832-0b675b20fad5/go.mod h1:9ncsQIHIbSJlBI0Af0uXKHqFkb3A3uLlS1SUovsaNw4=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/vendor/github.com/sapcc/go-bits/LICENSE
+++ b/vendor/github.com/sapcc/go-bits/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/sapcc/go-bits/logg/log.go
+++ b/vendor/github.com/sapcc/go-bits/logg/log.go
@@ -1,0 +1,97 @@
+/*******************************************************************************
+*
+* Copyright 2017-2018 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// Package logg provides some convenience functions on top of the "log" package
+// from the stdlib. It always uses the stdlib's standard logger.
+//
+// The functions in this package work like log.Println() or like log.Printf()
+// depending on whether arguments are passed after the message string:
+//
+//	import (
+//		"log"
+//		"github.com/sapcc/go-bits/logg"
+//	)
+//
+//	//The following two are equivalent:
+//	logg.Info("starting up")
+//	std_log.Println("INFO: starting up")
+//
+//	//The following two are equivalent:
+//	logg.Info("listening on port %d", port)
+//	std_log.Printf("INFO: listening on port %d\n", port)
+package logg
+
+import (
+	stdlog "log"
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	//ShowDebug can be set to true to enable the display of debug logs.
+	ShowDebug = false
+	log       = stdlog.New(stdlog.Writer(), stdlog.Prefix(), stdlog.Flags())
+	mu        sync.Mutex
+)
+
+// SetLogger allows to define custom logger
+func SetLogger(l *stdlog.Logger) {
+	mu.Lock()
+	defer mu.Unlock()
+	log = l
+}
+
+// Fatal logs a fatal error and terminates the program.
+func Fatal(msg string, args ...any) {
+	doLog("FATAL: "+msg, args)
+	os.Exit(1)
+}
+
+// Error logs a non-fatal error.
+func Error(msg string, args ...any) {
+	doLog("ERROR: "+msg, args)
+}
+
+// Info logs an informational message.
+func Info(msg string, args ...any) {
+	doLog("INFO: "+msg, args)
+}
+
+// Debug logs a debug message if debug logging is enabled.
+func Debug(msg string, args ...any) {
+	if ShowDebug {
+		doLog("DEBUG: "+msg, args)
+	}
+}
+
+// Other logs a message with a custom log level.
+func Other(level, msg string, args ...any) {
+	doLog(level+": "+msg, args)
+}
+
+func doLog(msg string, args []any) {
+	msg = strings.TrimSpace(msg)                //most importantly, skip trailing '\n'
+	msg = strings.Replace(msg, "\n", "\\n", -1) //avoid multiline log messages
+	if len(args) > 0 {
+		log.Printf(msg+"\n", args...)
+	} else {
+		log.Println(msg)
+	}
+}

--- a/vendor/github.com/sapcc/go-bits/osext/doc.go
+++ b/vendor/github.com/sapcc/go-bits/osext/doc.go
@@ -1,0 +1,20 @@
+/******************************************************************************
+*
+*  Copyright 2022 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+// Package osext contains extensions to the standard library package "os".
+package osext

--- a/vendor/github.com/sapcc/go-bits/osext/env.go
+++ b/vendor/github.com/sapcc/go-bits/osext/env.go
@@ -1,0 +1,78 @@
+/******************************************************************************
+*
+*  Copyright 2022 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package osext
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/sapcc/go-bits/logg"
+)
+
+// NeedGetenv returns os.Getenv(key), or panics if the environment variable is
+// not set.
+func MustGetenv(key string) string {
+	val, err := NeedGetenv(key)
+	if err != nil {
+		logg.Fatal(err.Error())
+	}
+	return val
+}
+
+// NeedGetenv returns os.Getenv(key), or an error if the environment variable is
+// not set.
+func NeedGetenv(key string) (string, error) {
+	val := os.Getenv(key)
+	if val == "" {
+		return "", MissingEnvError{key}
+	}
+	return val, nil
+}
+
+// GetenvOrDefault returns os.Getenv(key), except that if the environment
+// variable is not set, the given default value will be returned instead.
+func GetenvOrDefault(key, defaultValue string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultValue
+	}
+	return val
+}
+
+// GetenvBool returns true if and only if the environment variable with the
+// given key exists and contains a string that strconv.ParseBool() recognizes as
+// true. Non-existent or malformed values will be coerced into "false".
+//
+// This method is commonly used for optional behavior flags, e.g. to activate
+// debug logging.
+func GetenvBool(key string) bool {
+	val, err := strconv.ParseBool(os.Getenv(key))
+	return val && err == nil
+}
+
+// MissingEnvError is an error that occurs when an required environment variable was not present.
+type MissingEnvError struct {
+	Key string
+}
+
+// Error implements the builtin/error interface.
+func (e MissingEnvError) Error() string {
+	return fmt.Sprintf("environment variable %q is not set", e.Key)
+}

--- a/vendor/github.com/sapcc/go-bits/secrets/external.go
+++ b/vendor/github.com/sapcc/go-bits/secrets/external.go
@@ -1,0 +1,40 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GetPasswordFromCommandIfRequested evaluates the $OS_PW_CMD environment
+// variable if it exists and $OS_PASSWORD has not been provided.
+func GetPasswordFromCommandIfRequested() error {
+	pwCmd := os.Getenv("OS_PW_CMD")
+	if pwCmd == "" || os.Getenv("OS_PASSWORD") != "" {
+		return nil
+	}
+	// Retrieve user's password from external command.
+	cmd := exec.Command("sh", "-c", pwCmd)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("could not execute OS_PW_CMD: %w", err)
+	}
+	os.Setenv("OS_PASSWORD", strings.TrimSuffix(string(out), "\n"))
+	return nil
+}

--- a/vendor/github.com/sapcc/go-bits/secrets/secrets.go
+++ b/vendor/github.com/sapcc/go-bits/secrets/secrets.go
@@ -1,0 +1,60 @@
+/*******************************************************************************
+*
+* Copyright 2020 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// Package secrets provides convenience functions for working with auth
+// credentials.
+package secrets
+
+import (
+	"github.com/sapcc/go-bits/osext"
+)
+
+// FromEnv holds either a plain text value or a key for the environment
+// variable from which the value can be retrieved.
+// The key has the format: `{ fromEnv: ENVIRONMENT_VARIABLE }`.
+type FromEnv string
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (p *FromEnv) UnmarshalYAML(unmarshal func(any) error) error {
+	//plain text value
+	var plainTextInput string
+	err := unmarshal(&plainTextInput)
+	if err == nil {
+		*p = FromEnv(plainTextInput)
+		return nil
+	}
+
+	//retrieve value from the given environment variable key
+	var envVariableInput struct {
+		Key string `yaml:"fromEnv"`
+	}
+	err = unmarshal(&envVariableInput)
+	if err != nil {
+		return err
+	}
+
+	valFromEnv, err := osext.NeedGetenv(envVariableInput.Key)
+	if err != nil {
+		return err
+	}
+
+	*p = FromEnv(valFromEnv)
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,6 +41,11 @@ github.com/sapcc/go-api-declarations/internal/marshal
 github.com/sapcc/go-api-declarations/limes
 github.com/sapcc/go-api-declarations/limes/rates
 github.com/sapcc/go-api-declarations/limes/resources
+# github.com/sapcc/go-bits v0.0.0-20231213211425-ddd5e41f8535
+## explicit; go 1.21
+github.com/sapcc/go-bits/logg
+github.com/sapcc/go-bits/osext
+github.com/sapcc/go-bits/secrets
 # github.com/sapcc/gophercloud-sapcc v0.0.0-20231214091214-e4517ca1b6a4
 ## explicit; go 1.21
 github.com/sapcc/gophercloud-sapcc/clients

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,6 +41,11 @@ github.com/sapcc/go-api-declarations/internal/marshal
 github.com/sapcc/go-api-declarations/limes
 github.com/sapcc/go-api-declarations/limes/rates
 github.com/sapcc/go-api-declarations/limes/resources
+# github.com/sapcc/go-bits v0.0.0-20231221010852-98deb05b5d97
+## explicit; go 1.21
+github.com/sapcc/go-bits/logg
+github.com/sapcc/go-bits/osext
+github.com/sapcc/go-bits/secrets
 # github.com/sapcc/gophercloud-sapcc v0.0.0-20231221015832-0b675b20fad5
 ## explicit; go 1.21
 github.com/sapcc/gophercloud-sapcc/clients


### PR DESCRIPTION
Implement the go-bits password cmd read and add it to limesctl.

Edit: Merged the previous commit with the old gophercloud dependencies (before the renovate updates). Fixed that with the last push.