### PR TITLE
add `limesctl ops validate-quota-overrides` subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gophercloud/gophercloud v1.11.0
 	github.com/gophercloud/utils v0.0.0-20231010081019-80377eca5d56
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/sapcc/go-api-declarations v1.10.12
+	github.com/sapcc/go-api-declarations v1.11.0
 	github.com/sapcc/go-bits v0.0.0-20240418035538-c509bd89fb1a
 	github.com/sapcc/gophercloud-sapcc v0.0.0-20240418091604-612364ab440e
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sapcc/go-api-declarations v1.10.12 h1:F6FIoXE8bZUqKUM8azdGa4j5CpVZI8OF/qL5N5QMDJg=
-github.com/sapcc/go-api-declarations v1.10.12/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
+github.com/sapcc/go-api-declarations v1.11.0 h1:k/U/Hdv2UbBdAyxfnWUyhs8hl74fCrNn8aIWj+k42u4=
+github.com/sapcc/go-api-declarations v1.11.0/go.mod h1:83R3hTANhuRXt/pXDby37IJetw8l7DG41s33Tp9NXxI=
 github.com/sapcc/go-bits v0.0.0-20240418035538-c509bd89fb1a h1:RUbenVu0nFAWB4+CCid3Ot8AmUpr8Evj4adsInNv53s=
 github.com/sapcc/go-bits v0.0.0-20240418035538-c509bd89fb1a/go.mod h1:S1TKBMocQOBIZJUTJiLpNqXLB+G1A5OdTFiPpWaX4L4=
 github.com/sapcc/gophercloud-sapcc v0.0.0-20240418091604-612364ab440e h1:Z2Ge425CmuKb2HvI/NydrNYq9Jajxx+jOtunFE6/pnc=

--- a/internal/cmd/ops.go
+++ b/internal/cmd/ops.go
@@ -1,0 +1,104 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sapcc/go-api-declarations/limes"
+	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
+	"github.com/sapcc/gophercloud-sapcc/resources/v1/projects"
+	"github.com/spf13/cobra"
+
+	"github.com/sapcc/limesctl/v3/internal/auth"
+	"github.com/sapcc/limesctl/v3/internal/util"
+)
+
+func newOpsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ops",
+		Short: "Toolbox for Limes operators (end users do not need this)",
+		Args:  cobra.NoArgs,
+	}
+	// Flags
+	doNotSortFlags(cmd)
+	// Subcommands
+	cmd.AddCommand(newOpsValidateQuotaOverridesCmd())
+	return cmd
+}
+
+func newOpsValidateQuotaOverridesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate-quota-overrides path",
+		Short: "Validate a quota-overrides.json file for usage with an existing Limes instance",
+		Long: `Validate a quota-overrides.json file for usage with an existing Limes instance.
+
+Requies project member permissions.`,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: authWithLimesResources,
+		RunE:    runValidateQuotaOverrides,
+	}
+}
+
+func runValidateQuotaOverrides(cmd *cobra.Command, args []string) error {
+	buf, err := os.ReadFile(args[0])
+	if err != nil {
+		return err
+	}
+
+	// get resource report for the project from the current token scope
+	pInfo, err := auth.FindProject(identityClient, "", "")
+	if err != nil {
+		return err
+	}
+	report, err := projects.Get(limesResourcesClient, pInfo.DomainID, pInfo.ID, projects.GetOpts{}).Extract()
+	if err != nil {
+		return util.WrapError(err, "could not get project report")
+	}
+
+	// parse quota-overrides.json file using the existing report as
+	// a hint for which services/resources exist with which units
+	getUnit := func(serviceType limes.ServiceType, resourceName limesresources.ResourceName) (limes.Unit, error) {
+		srvReport := report.Services[serviceType]
+		if srvReport == nil {
+			return limes.UnitUnspecified, fmt.Errorf("%q is not a valid service", serviceType)
+		}
+		resReport := srvReport.Resources[resourceName]
+		if resReport == nil {
+			fullResourceName := fmt.Sprintf("%s/%s", serviceType, resourceName)
+			return limes.UnitUnspecified, fmt.Errorf("%q is not a valid resource", fullResourceName)
+		}
+		if resReport.Quota == nil {
+			return limes.UnitUnspecified, fmt.Errorf("%s/%s does not track quota", serviceType, resourceName)
+		}
+		return resReport.Unit, nil
+	}
+	_, errs := limesresources.ParseQuotaOverrides(buf, getUnit)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
+		}
+		return errors.New("validation failed")
+	}
+
+	return nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -93,6 +93,7 @@ func newRootCmd(v *VersionInfo) *cobra.Command {
 	cmd.AddCommand(newClusterCmd())
 	cmd.AddCommand(newDomainCmd())
 	cmd.AddCommand(newProjectCmd())
+	cmd.AddCommand(newOpsCmd())
 
 	return cmd
 }

--- a/vendor/github.com/sapcc/go-api-declarations/limes/resources/overrides.go
+++ b/vendor/github.com/sapcc/go-api-declarations/limes/resources/overrides.go
@@ -1,0 +1,90 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package limesresources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sapcc/go-api-declarations/limes"
+)
+
+// ParseQuotaOverrides parses the contents of a quota-overrides.json file.
+// This is the format expected by Limes at $LIMES_QUOTA_OVERRIDES_PATH.
+// This code lives here because it is also used in `limesctl validate-quota-overrides`.
+func ParseQuotaOverrides(buf []byte, getUnit func(limes.ServiceType, ResourceName) (limes.Unit, error)) (result map[string]map[string]map[limes.ServiceType]map[ResourceName]uint64, errs []error) {
+	var parsed map[string]map[string]map[limes.ServiceType]map[ResourceName]json.RawMessage
+	err := json.Unmarshal(buf, &parsed)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	result = make(map[string]map[string]map[limes.ServiceType]map[ResourceName]uint64)
+	for domainName, domainInputs := range parsed {
+		domainResult := make(map[string]map[limes.ServiceType]map[ResourceName]uint64)
+		for projectName, projectInputs := range domainInputs {
+			projectResult := make(map[limes.ServiceType]map[ResourceName]uint64)
+			for serviceType, serviceInputs := range projectInputs {
+				serviceResult := make(map[ResourceName]uint64)
+				for resourceName, inputJSON := range serviceInputs {
+					unit, err := getUnit(serviceType, resourceName)
+					if err != nil {
+						errs = append(errs, err)
+						continue
+					}
+					value, err := parseSingleQuotaOverrideValue(inputJSON, serviceType, resourceName, unit)
+					if err == nil {
+						serviceResult[resourceName] = value
+					} else {
+						errs = append(errs, err)
+					}
+				}
+				projectResult[serviceType] = serviceResult
+			}
+			domainResult[projectName] = projectResult
+		}
+		result[domainName] = domainResult
+	}
+	return result, errs
+}
+
+func parseSingleQuotaOverrideValue(input json.RawMessage, serviceType limes.ServiceType, resourceName ResourceName, unit limes.Unit) (uint64, error) {
+	// case 1: counted resources represent quota as a single number
+	if unit == limes.UnitNone {
+		var value uint64
+		err := json.Unmarshal([]byte(input), &value)
+		if err != nil {
+			return 0, fmt.Errorf("expected uint64 value for %s/%s, but got %q", serviceType, resourceName, string(input))
+		}
+		return value, nil
+	}
+
+	// case 2: measured resources represent quota as a string of value with unit
+	var value string
+	err := json.Unmarshal([]byte(input), &value)
+	if err != nil {
+		return 0, fmt.Errorf("expected string field for %s/%s, but got %q", serviceType, resourceName, string(input))
+	}
+	parsedValue, err := unit.Parse(value)
+	if err != nil {
+		return 0, fmt.Errorf("in value for %s/%s: %w", serviceType, resourceName, err)
+	}
+	return parsedValue, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/mitchellh/go-homedir
 # github.com/olekukonko/tablewriter v0.0.5
 ## explicit; go 1.12
 github.com/olekukonko/tablewriter
-# github.com/sapcc/go-api-declarations v1.10.12
+# github.com/sapcc/go-api-declarations v1.11.0
 ## explicit; go 1.21
 github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/internal/marshal


### PR DESCRIPTION
This is to automatically validate a quota-overrides.json file before deploying it into a Limes installation.