### PR TITLE
fix new lints

### DIFF
--- a/internal/auth/project.go
+++ b/internal/auth/project.go
@@ -121,7 +121,8 @@ func findProjectInCurrentToken(identityClient *gophercloud.ServiceClient, domain
 		return nil
 	}
 
-	if projectNameOrID == "" {
+	switch projectNameOrID {
+	case "":
 		// If no projectNameOrID is provided then we return the info from token.
 		if d1.ID != "" {
 			return &ProjectInfo{
@@ -137,7 +138,7 @@ func findProjectInCurrentToken(identityClient *gophercloud.ServiceClient, domain
 				DomainName: d2.Name,
 			}
 		}
-	} else if projectNameOrID == p.ID || projectNameOrID == p.Name {
+	case p.ID, p.Name:
 		// Check if token has the given name/ID(s).
 		if d1.ID != "" && (domainNameOrID == d1.ID || domainNameOrID == d1.Name) {
 			return &ProjectInfo{

--- a/internal/cmd/cluster.go
+++ b/internal/cmd/cluster.go
@@ -43,8 +43,8 @@ func newClusterCmd() *cobra.Command {
 type clusterShowCmd struct {
 	*cobra.Command
 
-	resourceFilterFlags
-	resourceOutputFmtFlags
+	filterFlags    resourceFilterFlags
+	outputFmtFlags resourceOutputFmtFlags
 }
 
 func newClusterShowCmd() *clusterShowCmd {
@@ -60,29 +60,29 @@ func newClusterShowCmd() *clusterShowCmd {
 
 	// Flags
 	doNotSortFlags(cmd)
-	clusterShow.resourceFilterFlags.AddToCmd(cmd)
-	clusterShow.resourceOutputFmtFlags.AddToCmd(cmd)
+	clusterShow.filterFlags.AddToCmd(cmd)
+	clusterShow.outputFmtFlags.AddToCmd(cmd)
 
 	clusterShow.Command = cmd
 	return clusterShow
 }
 
 func (c *clusterShowCmd) Run(cmd *cobra.Command, _ []string) error {
-	outputOpts, err := c.resourceOutputFmtFlags.validate()
+	outputOpts, err := c.outputFmtFlags.validate()
 	if err != nil {
 		return err
 	}
 
 	res := clusters.Get(cmd.Context(), limesResourcesClient, clusters.GetOpts{
-		Areas:     c.areas,
-		Services:  util.CastStringsTo[limes.ServiceType](c.services),
-		Resources: util.CastStringsTo[limesresources.ResourceName](c.resources),
+		Areas:     c.filterFlags.areas,
+		Services:  util.CastStringsTo[limes.ServiceType](c.filterFlags.services),
+		Resources: util.CastStringsTo[limesresources.ResourceName](c.filterFlags.resources),
 	})
 	if res.Err != nil {
 		return util.WrapError(res.Err, "could not get cluster report")
 	}
 
-	if c.format == core.OutputFormatJSON {
+	if c.outputFmtFlags.format == core.OutputFormatJSON {
 		return writeJSON(res.Body)
 	}
 
@@ -100,8 +100,8 @@ func (c *clusterShowCmd) Run(cmd *cobra.Command, _ []string) error {
 type clusterShowRatesCmd struct {
 	*cobra.Command
 
-	rateFilterFlags
-	rateOutputFmtFlags
+	filterFlags    rateFilterFlags
+	outputFmtFlags rateOutputFmtFlags
 }
 
 func newClusterShowRatesCmd() *clusterShowRatesCmd {
@@ -117,28 +117,28 @@ func newClusterShowRatesCmd() *clusterShowRatesCmd {
 
 	// Flags
 	doNotSortFlags(cmd)
-	clusterShowRates.rateFilterFlags.AddToCmd(cmd)
-	clusterShowRates.rateOutputFmtFlags.AddToCmd(cmd)
+	clusterShowRates.filterFlags.AddToCmd(cmd)
+	clusterShowRates.outputFmtFlags.AddToCmd(cmd)
 
 	clusterShowRates.Command = cmd
 	return clusterShowRates
 }
 
 func (c *clusterShowRatesCmd) Run(cmd *cobra.Command, args []string) error {
-	outputOpts, err := c.rateOutputFmtFlags.validate()
+	outputOpts, err := c.outputFmtFlags.validate()
 	if err != nil {
 		return err
 	}
 
 	res := ratesClusters.Get(cmd.Context(), limesRatesClient, ratesClusters.GetOpts{
-		Areas:    c.areas,
-		Services: util.CastStringsTo[limes.ServiceType](c.services),
+		Areas:    c.filterFlags.areas,
+		Services: util.CastStringsTo[limes.ServiceType](c.filterFlags.services),
 	})
 	if res.Err != nil {
 		return util.WrapError(res.Err, "could not get cluster report")
 	}
 
-	if c.format == core.OutputFormatJSON {
+	if c.outputFmtFlags.format == core.OutputFormatJSON {
 		return writeJSON(res.Body)
 	}
 

--- a/internal/cmd/domain.go
+++ b/internal/cmd/domain.go
@@ -45,8 +45,8 @@ func newDomainCmd() *cobra.Command {
 type domainListCmd struct {
 	*cobra.Command
 
-	resourceFilterFlags
-	resourceOutputFmtFlags
+	filterFlags    resourceFilterFlags
+	outputFmtFlags resourceOutputFmtFlags
 }
 
 func newDomainListCmd() *domainListCmd {
@@ -63,29 +63,29 @@ cloud-admin token.`,
 
 	// Flags
 	doNotSortFlags(cmd)
-	domainList.resourceFilterFlags.AddToCmd(cmd)
-	domainList.resourceOutputFmtFlags.AddToCmd(cmd)
+	domainList.filterFlags.AddToCmd(cmd)
+	domainList.outputFmtFlags.AddToCmd(cmd)
 
 	domainList.Command = cmd
 	return domainList
 }
 
 func (d *domainListCmd) Run(cmd *cobra.Command, _ []string) error {
-	outputOpts, err := d.resourceOutputFmtFlags.validate()
+	outputOpts, err := d.outputFmtFlags.validate()
 	if err != nil {
 		return err
 	}
 
 	res := domains.List(cmd.Context(), limesResourcesClient, domains.ListOpts{
-		Areas:     d.areas,
-		Services:  util.CastStringsTo[limes.ServiceType](d.services),
-		Resources: util.CastStringsTo[limesresources.ResourceName](d.resources),
+		Areas:     d.filterFlags.areas,
+		Services:  util.CastStringsTo[limes.ServiceType](d.filterFlags.services),
+		Resources: util.CastStringsTo[limesresources.ResourceName](d.filterFlags.resources),
 	})
 	if res.Err != nil {
 		return util.WrapError(res.Err, "could not get domain reports")
 	}
 
-	if d.format == core.OutputFormatJSON {
+	if d.outputFmtFlags.format == core.OutputFormatJSON {
 		return writeJSON(res.Body)
 	}
 
@@ -103,8 +103,8 @@ func (d *domainListCmd) Run(cmd *cobra.Command, _ []string) error {
 type domainShowCmd struct {
 	*cobra.Command
 
-	resourceFilterFlags
-	resourceOutputFmtFlags
+	filterFlags    resourceFilterFlags
+	outputFmtFlags resourceOutputFmtFlags
 }
 
 func newDomainShowCmd() *domainShowCmd {
@@ -121,15 +121,15 @@ domain-admin token.`,
 
 	// Flags
 	doNotSortFlags(cmd)
-	domainShow.resourceFilterFlags.AddToCmd(cmd)
-	domainShow.resourceOutputFmtFlags.AddToCmd(cmd)
+	domainShow.filterFlags.AddToCmd(cmd)
+	domainShow.outputFmtFlags.AddToCmd(cmd)
 
 	domainShow.Command = cmd
 	return domainShow
 }
 
 func (d *domainShowCmd) Run(cmd *cobra.Command, args []string) error {
-	outputOpts, err := d.resourceOutputFmtFlags.validate()
+	outputOpts, err := d.outputFmtFlags.validate()
 	if err != nil {
 		return err
 	}
@@ -144,15 +144,15 @@ func (d *domainShowCmd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	res := domains.Get(cmd.Context(), limesResourcesClient, domainID, domains.GetOpts{
-		Areas:     d.areas,
-		Services:  util.CastStringsTo[limes.ServiceType](d.services),
-		Resources: util.CastStringsTo[limesresources.ResourceName](d.resources),
+		Areas:     d.filterFlags.areas,
+		Services:  util.CastStringsTo[limes.ServiceType](d.filterFlags.services),
+		Resources: util.CastStringsTo[limesresources.ResourceName](d.filterFlags.resources),
 	})
 	if res.Err != nil {
 		return util.WrapError(res.Err, "could not get domain report")
 	}
 
-	if d.format == core.OutputFormatJSON {
+	if d.outputFmtFlags.format == core.OutputFormatJSON {
 		return writeJSON(res.Body)
 	}
 

--- a/internal/cmd/liquid.go
+++ b/internal/cmd/liquid.go
@@ -58,7 +58,7 @@ func newLiquidCmd() *cobra.Command {
 type liquidServiceInfoCmd struct {
 	*cobra.Command
 
-	liquidOperationFlags
+	flags liquidOperationFlags
 }
 
 func newLiquidServiceInfoCmd() *liquidServiceInfoCmd {
@@ -73,7 +73,7 @@ func newLiquidServiceInfoCmd() *liquidServiceInfoCmd {
 
 	// Flags
 	doNotSortFlags(cmd)
-	liquidServiceInfo.liquidOperationFlags.AddToCmd(cmd)
+	liquidServiceInfo.flags.AddToCmd(cmd)
 
 	liquidServiceInfo.Command = cmd
 	return liquidServiceInfo
@@ -102,12 +102,12 @@ func (c *liquidServiceInfoCmd) Run(cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		serviceType = args[0]
 	}
-	endpoint := c.liquidOperationFlags.endpoint
-	compare := c.liquidOperationFlags.compare
+	endpoint := c.flags.endpoint
+	compare := c.flags.compare
 	if compare && (endpoint == "" || serviceType == "") {
 		return errors.New("argument $SERVICE_TYPE and flag --endpoint are both required for comparison mode")
 	}
-	body := c.liquidOperationFlags.body
+	body := c.flags.body
 	if body != "" {
 		return errors.New("custom request body is not needed when retrieving service info")
 	}
@@ -153,7 +153,7 @@ func (c *liquidServiceInfoCmd) Run(cmd *cobra.Command, args []string) error {
 type liquidReportCapacityCmd struct {
 	*cobra.Command
 
-	liquidOperationFlags
+	flags liquidOperationFlags
 }
 
 func newLiquidReportCapacityCmd() *liquidReportCapacityCmd {
@@ -169,7 +169,7 @@ func newLiquidReportCapacityCmd() *liquidReportCapacityCmd {
 
 	// Flags
 	doNotSortFlags(cmd)
-	liquidReportCapacity.liquidOperationFlags.AddToCmd(cmd)
+	liquidReportCapacity.flags.AddToCmd(cmd)
 
 	liquidReportCapacity.Command = cmd
 	return liquidReportCapacity
@@ -196,12 +196,12 @@ func GetLiquidCapacityReport(provider *gophercloud.ProviderClient, opts liquidap
 func (c *liquidReportCapacityCmd) Run(cmd *cobra.Command, args []string) error {
 	serviceType := args[0]
 
-	endpoint := c.liquidOperationFlags.endpoint
-	compare := c.liquidOperationFlags.compare
+	endpoint := c.flags.endpoint
+	compare := c.flags.compare
 	if compare && (endpoint == "" || serviceType == "") {
 		return errors.New("argument $SERVICE_TYPE and flag --endpoint are both required for comparison mode")
 	}
-	body := c.liquidOperationFlags.body
+	body := c.flags.body
 
 	var serviceCapacityRequest *liquid.ServiceCapacityRequest
 	if body == "" {
@@ -267,7 +267,7 @@ func (c *liquidReportCapacityCmd) Run(cmd *cobra.Command, args []string) error {
 type liquidReportUsageCmd struct {
 	*cobra.Command
 
-	liquidOperationFlags
+	flags liquidOperationFlags
 }
 
 func newLiquidReportUsageCmd() *liquidReportUsageCmd {
@@ -283,7 +283,7 @@ func newLiquidReportUsageCmd() *liquidReportUsageCmd {
 
 	// Flags
 	doNotSortFlags(cmd)
-	liquidReportUsage.liquidOperationFlags.AddToCmd(cmd)
+	liquidReportUsage.flags.AddToCmd(cmd)
 
 	liquidReportUsage.Command = cmd
 	return liquidReportUsage
@@ -311,12 +311,12 @@ func (c *liquidReportUsageCmd) Run(cmd *cobra.Command, args []string) error {
 	serviceType := args[0]
 	projectID := args[1]
 
-	endpoint := c.liquidOperationFlags.endpoint
-	compare := c.liquidOperationFlags.compare
+	endpoint := c.flags.endpoint
+	compare := c.flags.compare
 	if compare && (endpoint == "" || serviceType == "") {
 		return errors.New("argument $SERVICE_TYPE and flag --endpoint are both required for comparison mode")
 	}
-	body := c.liquidOperationFlags.body
+	body := c.flags.body
 
 	var serviceUsageRequest *liquid.ServiceUsageRequest
 	if body == "" {
@@ -382,7 +382,7 @@ func (c *liquidReportUsageCmd) Run(cmd *cobra.Command, args []string) error {
 type liquidSetQuotaCmd struct {
 	*cobra.Command
 
-	liquidQuotaOperationFlags
+	flags liquidQuotaOperationFlags
 }
 
 func newLiquidSetQuotaCmd() *liquidSetQuotaCmd {
@@ -397,7 +397,7 @@ func newLiquidSetQuotaCmd() *liquidSetQuotaCmd {
 
 	// Flags
 	doNotSortFlags(cmd)
-	liquidSetQuota.liquidQuotaOperationFlags.AddToCmd(cmd)
+	liquidSetQuota.flags.AddToCmd(cmd)
 
 	liquidSetQuota.Command = cmd
 	return liquidSetQuota
@@ -407,14 +407,14 @@ func (c *liquidSetQuotaCmd) Run(cmd *cobra.Command, args []string) error {
 	serviceType := args[0]
 	projectID := args[1]
 
-	endpoint := c.liquidQuotaOperationFlags.endpoint
+	endpoint := c.flags.endpoint
 
-	if len(c.liquidQuotaOperationFlags.quotaValues) == 0 {
+	if len(c.flags.quotaValues) == 0 {
 		return errors.New("flag --quota-values is required")
 	}
 	var serviceQuotaRequest liquid.ServiceQuotaRequest
 	serviceQuotaRequest.Resources = make(map[liquid.ResourceName]liquid.ResourceQuotaRequest)
-	resourceQuotaStrings := c.liquidQuotaOperationFlags.quotaValues
+	resourceQuotaStrings := c.flags.quotaValues
 	for _, resourceQuotaString := range resourceQuotaStrings {
 		parts := strings.Split(resourceQuotaString, "=")
 		if len(parts) != 2 {


### PR DESCRIPTION
staticcheck has a new lint, QF1008, to remove superfluous references to embedded fields. Because we have flagsets as embedded fields in our commands, this results in nonsensical invocations, e.g. "cmd.validate()" which really means "cmd.someFlagSet.validate()".

To avoid that, this changeset makes all the flagsets regular fields in their command structs.