### PR TITLE
add mail template command

### DIFF
--- a/internal/cmd/cluster.go
+++ b/internal/cmd/cluster.go
@@ -4,6 +4,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	ratesClusters "github.com/sapcc/gophercloud-sapcc/v2/rates/v1/clusters"
@@ -23,6 +26,7 @@ func newClusterCmd() *cobra.Command {
 	doNotSortFlags(cmd)
 	cmd.AddCommand(newClusterShowCmd().Command)
 	cmd.AddCommand(newClusterShowRatesCmd().Command)
+	cmd.AddCommand(newClusterMailTemplateRenderer().Command)
 	return cmd
 }
 
@@ -139,4 +143,85 @@ func (c *clusterShowRatesCmd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return writeReports(outputOpts, core.ClusterRatesReport{ClusterReport: limesRep})
+}
+
+type clusterMailTemplate struct {
+	*cobra.Command
+
+	jsonOutput             bool
+	confirmedCommitments   bool
+	expiringCommitments    bool
+	transferredCommitments bool
+}
+
+type mailTemplates struct {
+	ConfirmedCommitments   string `json:"confirmed_commitments"`
+	ExpiringCommitments    string `json:"expiring_commitments"`
+	TransferredCommitments string `json:"transferred_commitments"`
+}
+
+func newClusterMailTemplateRenderer() *clusterMailTemplate {
+	clusterMail := &clusterMailTemplate{}
+	cmd := &cobra.Command{
+		Use:     "show-mail-templates",
+		Short:   "Display configured mail templates.",
+		Long:    "Display configured mail templates. Can be used to check the validity of the configured templates.",
+		Args:    cobra.NoArgs,
+		PreRunE: authWithLimesAdmin,
+		RunE:    clusterMail.Run,
+	}
+
+	// Flags
+	doNotSortFlags(cmd)
+	cmd.Flags().BoolVar(&clusterMail.jsonOutput, "json", false, "output as JSON (with escaped HTML characters)")
+	cmd.Flags().BoolVar(&clusterMail.confirmedCommitments, "confirmed", false, "show only confirmed commitments template")
+	cmd.Flags().BoolVar(&clusterMail.expiringCommitments, "expiring", false, "show only expiring commitments template")
+	cmd.Flags().BoolVar(&clusterMail.transferredCommitments, "transferred", false, "show only transferred commitments template")
+	clusterMail.Command = cmd
+	return clusterMail
+}
+
+// Run is called by Cobra when this command is executed.
+func (c *clusterMailTemplate) Run(cmd *cobra.Command, args []string) error {
+	var res gophercloud.Result
+	resp, err := limesAdminClient.Get(cmd.Context(), limesAdminClient.ServiceURL("mail/render"), &res.Body, nil) //nolint:bodyclose
+	_, _, res.Err = gophercloud.ParseResponse(resp, err)
+	if res.Err != nil {
+		return util.WrapError(res.Err, "could not fetch mail template request body from limes")
+	}
+
+	templates := &mailTemplates{}
+	err = res.ExtractInto(templates)
+	if err != nil {
+		return util.WrapError(err, "could not extract mail templates")
+	}
+
+	switch {
+	case c.confirmedCommitments:
+		if c.jsonOutput {
+			return writeJSON(templates.ConfirmedCommitments)
+		}
+		fmt.Println(templates.ConfirmedCommitments)
+		return nil
+	case c.expiringCommitments:
+		if c.jsonOutput {
+			return writeJSON(templates.ExpiringCommitments)
+		}
+		fmt.Println(templates.ExpiringCommitments)
+		return nil
+	case c.transferredCommitments:
+		if c.jsonOutput {
+			return writeJSON(templates.TransferredCommitments)
+		}
+		fmt.Println(templates.TransferredCommitments)
+		return nil
+	default:
+		if c.jsonOutput {
+			return writeJSON(res.Body)
+		}
+		fmt.Println(templates.ConfirmedCommitments)
+		fmt.Println(templates.ExpiringCommitments)
+		fmt.Println(templates.TransferredCommitments)
+		return nil
+	}
 }

--- a/internal/cmd/cluster.go
+++ b/internal/cmd/cluster.go
@@ -4,9 +4,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/gophercloud/gophercloud/v2"
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 	ratesClusters "github.com/sapcc/gophercloud-sapcc/v2/rates/v1/clusters"
@@ -26,7 +23,7 @@ func newClusterCmd() *cobra.Command {
 	doNotSortFlags(cmd)
 	cmd.AddCommand(newClusterShowCmd().Command)
 	cmd.AddCommand(newClusterShowRatesCmd().Command)
-	cmd.AddCommand(newClusterMailTemplateRenderer().Command)
+	cmd.AddCommand(newMailTemplateCmd())
 	return cmd
 }
 
@@ -143,85 +140,4 @@ func (c *clusterShowRatesCmd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return writeReports(outputOpts, core.ClusterRatesReport{ClusterReport: limesRep})
-}
-
-type clusterMailTemplate struct {
-	*cobra.Command
-
-	jsonOutput             bool
-	confirmedCommitments   bool
-	expiringCommitments    bool
-	transferredCommitments bool
-}
-
-type mailTemplates struct {
-	ConfirmedCommitments   string `json:"confirmed_commitments"`
-	ExpiringCommitments    string `json:"expiring_commitments"`
-	TransferredCommitments string `json:"transferred_commitments"`
-}
-
-func newClusterMailTemplateRenderer() *clusterMailTemplate {
-	clusterMail := &clusterMailTemplate{}
-	cmd := &cobra.Command{
-		Use:     "show-mail-templates",
-		Short:   "Display configured mail templates.",
-		Long:    "Display configured mail templates. Can be used to check the validity of the configured templates.",
-		Args:    cobra.NoArgs,
-		PreRunE: authWithLimesAdmin,
-		RunE:    clusterMail.Run,
-	}
-
-	// Flags
-	doNotSortFlags(cmd)
-	cmd.Flags().BoolVar(&clusterMail.jsonOutput, "json", false, "output as JSON (with escaped HTML characters)")
-	cmd.Flags().BoolVar(&clusterMail.confirmedCommitments, "confirmed", false, "show only confirmed commitments template")
-	cmd.Flags().BoolVar(&clusterMail.expiringCommitments, "expiring", false, "show only expiring commitments template")
-	cmd.Flags().BoolVar(&clusterMail.transferredCommitments, "transferred", false, "show only transferred commitments template")
-	clusterMail.Command = cmd
-	return clusterMail
-}
-
-// Run is called by Cobra when this command is executed.
-func (c *clusterMailTemplate) Run(cmd *cobra.Command, args []string) error {
-	var res gophercloud.Result
-	resp, err := limesAdminClient.Get(cmd.Context(), limesAdminClient.ServiceURL("mail/render"), &res.Body, nil) //nolint:bodyclose
-	_, _, res.Err = gophercloud.ParseResponse(resp, err)
-	if res.Err != nil {
-		return util.WrapError(res.Err, "could not fetch mail template request body from limes")
-	}
-
-	templates := &mailTemplates{}
-	err = res.ExtractInto(templates)
-	if err != nil {
-		return util.WrapError(err, "could not extract mail templates")
-	}
-
-	switch {
-	case c.confirmedCommitments:
-		if c.jsonOutput {
-			return writeJSON(templates.ConfirmedCommitments)
-		}
-		fmt.Println(templates.ConfirmedCommitments)
-		return nil
-	case c.expiringCommitments:
-		if c.jsonOutput {
-			return writeJSON(templates.ExpiringCommitments)
-		}
-		fmt.Println(templates.ExpiringCommitments)
-		return nil
-	case c.transferredCommitments:
-		if c.jsonOutput {
-			return writeJSON(templates.TransferredCommitments)
-		}
-		fmt.Println(templates.TransferredCommitments)
-		return nil
-	default:
-		if c.jsonOutput {
-			return writeJSON(res.Body)
-		}
-		fmt.Println(templates.ConfirmedCommitments)
-		fmt.Println(templates.ExpiringCommitments)
-		fmt.Println(templates.TransferredCommitments)
-		return nil
-	}
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -55,6 +55,15 @@ func (f *rateFilterFlags) AddToCmd(cmd *cobra.Command) {
 	f.commonFilterFlags.AddToCmd(cmd)
 }
 
+// mailTemplateFlags define parameters for Limes API requests that concern mail templates.
+type mailTemplateFlags struct {
+	jsonOutput bool
+}
+
+func (f *mailTemplateFlags) AddToCmd(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "JSON output with escaped HTML characters")
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // CLI output format flags.
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -55,16 +55,6 @@ func (f *rateFilterFlags) AddToCmd(cmd *cobra.Command) {
 	f.commonFilterFlags.AddToCmd(cmd)
 }
 
-// mailTemplateFlags define parameters that concern mail templates.
-type mailTemplateFlags struct {
-	jsonOutput bool
-}
-
-// AddToCmd adds the mailTemplateFlags to the cobra.Command.
-func (f *mailTemplateFlags) AddToCmd(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "JSON output with escaped HTML characters")
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // CLI output format flags.
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -55,7 +55,7 @@ func (f *rateFilterFlags) AddToCmd(cmd *cobra.Command) {
 	f.commonFilterFlags.AddToCmd(cmd)
 }
 
-// mailTemplateFlags define parameters for Limes API requests that concern mail templates.
+// mailTemplateFlags define parameters that concern mail templates.
 type mailTemplateFlags struct {
 	jsonOutput bool
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -60,6 +60,7 @@ type mailTemplateFlags struct {
 	jsonOutput bool
 }
 
+// AddToCmd adds the mailTemplateFlags to the cobra.Command.
 func (f *mailTemplateFlags) AddToCmd(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "JSON output with escaped HTML characters")
 }

--- a/internal/cmd/mail_template.go
+++ b/internal/cmd/mail_template.go
@@ -12,19 +12,19 @@ import (
 	"github.com/sapcc/limesctl/v3/internal/util"
 )
 
-// MailTemplates holds the rendered mail templates from the API.
-type MailTemplates struct {
+// mailTemplates holds the rendered mail templates from the API.
+type mailTemplates struct {
 	ConfirmedCommitments   string `json:"confirmed_commitments"`
 	ExpiringCommitments    string `json:"expiring_commitments"`
 	TransferredCommitments string `json:"transferred_commitments"`
 }
 
 func newMailTemplateCmd() *cobra.Command {
-	var fetchedMailTemplates *MailTemplates
+	var fetchedMailTemplates *mailTemplates
 
 	// subcommands can access the templates.
 	// called after PersistentPreRunE has populated the data.
-	getTemplates := func() *MailTemplates {
+	getTemplates := func() *mailTemplates {
 		return fetchedMailTemplates
 	}
 
@@ -44,7 +44,7 @@ func newMailTemplateCmd() *cobra.Command {
 				return util.WrapError(res.Err, "could not fetch mail templates from limes")
 			}
 
-			fetchedMailTemplates = &MailTemplates{}
+			fetchedMailTemplates = &mailTemplates{}
 			if err := res.ExtractInto(fetchedMailTemplates); err != nil {
 				return util.WrapError(err, "could not extract mail templates")
 			}
@@ -64,7 +64,7 @@ func newMailTemplateCmd() *cobra.Command {
 	return cmd
 }
 
-func newAllTemplatesCmd(getTemplates func() *MailTemplates) *cobra.Command {
+func newAllTemplatesCmd(getTemplates func() *mailTemplates) *cobra.Command {
 	var flags mailTemplateFlags
 
 	cmd := &cobra.Command{
@@ -95,7 +95,7 @@ func newAllTemplatesCmd(getTemplates func() *MailTemplates) *cobra.Command {
 	return cmd
 }
 
-func newConfirmedCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Command {
+func newConfirmedCommitmentsCmd(getTemplates func() *mailTemplates) *cobra.Command {
 	var flags mailTemplateFlags
 
 	cmd := &cobra.Command{
@@ -112,7 +112,7 @@ func newConfirmedCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Comma
 	return cmd
 }
 
-func newExpiringCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Command {
+func newExpiringCommitmentsCmd(getTemplates func() *mailTemplates) *cobra.Command {
 	var flags mailTemplateFlags
 
 	cmd := &cobra.Command{
@@ -129,7 +129,7 @@ func newExpiringCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Comman
 	return cmd
 }
 
-func newTransferredCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Command {
+func newTransferredCommitmentsCmd(getTemplates func() *mailTemplates) *cobra.Command {
 	var flags mailTemplateFlags
 
 	cmd := &cobra.Command{

--- a/internal/cmd/mail_template.go
+++ b/internal/cmd/mail_template.go
@@ -65,17 +65,12 @@ func newMailTemplateCmd() *cobra.Command {
 }
 
 func newAllTemplatesCmd(getTemplates func() *mailTemplates) *cobra.Command {
-	var flags mailTemplateFlags
-
 	cmd := &cobra.Command{
 		Use:   "all",
 		Short: "Display all mail templates",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			templates := getTemplates()
-			if flags.jsonOutput {
-				return writeJSON(templates)
-			}
 
 			fmt.Println("=== Confirmed Commitments ===")
 			fmt.Println(templates.ConfirmedCommitments)
@@ -91,67 +86,53 @@ func newAllTemplatesCmd(getTemplates func() *mailTemplates) *cobra.Command {
 	}
 
 	doNotSortFlags(cmd)
-	flags.AddToCmd(cmd)
 	return cmd
 }
 
 func newConfirmedCommitmentsCmd(getTemplates func() *mailTemplates) *cobra.Command {
-	var flags mailTemplateFlags
-
 	cmd := &cobra.Command{
 		Use:   "confirmed",
 		Short: "Display the confirmed commitments mail template",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return outputTemplate("confirmed_commitments", getTemplates().ConfirmedCommitments, flags.jsonOutput)
+			return outputTemplate(getTemplates().ConfirmedCommitments)
 		},
 	}
 
 	doNotSortFlags(cmd)
-	flags.AddToCmd(cmd)
 	return cmd
 }
 
 func newExpiringCommitmentsCmd(getTemplates func() *mailTemplates) *cobra.Command {
-	var flags mailTemplateFlags
-
 	cmd := &cobra.Command{
 		Use:   "expiring",
 		Short: "Display the expiring commitments mail template",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return outputTemplate("expiring_commitments", getTemplates().ExpiringCommitments, flags.jsonOutput)
+			return outputTemplate(getTemplates().ExpiringCommitments)
 		},
 	}
 
 	doNotSortFlags(cmd)
-	flags.AddToCmd(cmd)
 	return cmd
 }
 
 func newTransferredCommitmentsCmd(getTemplates func() *mailTemplates) *cobra.Command {
-	var flags mailTemplateFlags
-
 	cmd := &cobra.Command{
 		Use:   "transferred",
 		Short: "Display the transferred commitments mail template",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return outputTemplate("transferred_commitments", getTemplates().TransferredCommitments, flags.jsonOutput)
+			return outputTemplate(getTemplates().TransferredCommitments)
 		},
 	}
 
 	doNotSortFlags(cmd)
-	flags.AddToCmd(cmd)
 	return cmd
 }
 
-// outputTemplate handles the output of a single template with optional JSON formatting.
-func outputTemplate(name, content string, jsonOutput bool) error {
-	if jsonOutput {
-		output := map[string]string{name: content}
-		return writeJSON(output)
-	}
+// outputTemplate handles the output of a single template.
+func outputTemplate(content string) error {
 	fmt.Println(content)
 	return nil
 }

--- a/internal/cmd/mail_template.go
+++ b/internal/cmd/mail_template.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/sapcc/limesctl/v3/internal/util"
+)
+
+// MailTemplates holds the rendered mail templates from the API.
+type MailTemplates struct {
+	ConfirmedCommitments   string `json:"confirmed_commitments"`
+	ExpiringCommitments    string `json:"expiring_commitments"`
+	TransferredCommitments string `json:"transferred_commitments"`
+}
+
+func newMailTemplateCmd() *cobra.Command {
+	var fetchedMailTemplates *MailTemplates
+
+	// subcommands can access the templates.
+	// called after PersistentPreRunE has populated the data.
+	getTemplates := func() *MailTemplates {
+		return fetchedMailTemplates
+	}
+
+	cmd := &cobra.Command{
+		Use:   "mail-template",
+		Short: "Display configured mail templates",
+		Long:  "Display configured mail templates. Can be used to check the validity of the configured templates.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := authWithLimesAdmin(cmd, args); err != nil {
+				return err
+			}
+
+			var res gophercloud.Result
+			resp, err := limesAdminClient.Get(cmd.Context(), limesAdminClient.ServiceURL("mail/render"), &res.Body, nil) //nolint:bodyclose
+			_, _, res.Err = gophercloud.ParseResponse(resp, err)
+			if res.Err != nil {
+				return util.WrapError(res.Err, "could not fetch mail templates from limes")
+			}
+
+			fetchedMailTemplates = &MailTemplates{}
+			if err := res.ExtractInto(fetchedMailTemplates); err != nil {
+				return util.WrapError(err, "could not extract mail templates")
+			}
+
+			return nil
+		},
+	}
+
+	doNotSortFlags(cmd)
+
+	// Add subcommands
+	cmd.AddCommand(newAllTemplatesCmd(getTemplates))
+	cmd.AddCommand(newConfirmedCommitmentsCmd(getTemplates))
+	cmd.AddCommand(newExpiringCommitmentsCmd(getTemplates))
+	cmd.AddCommand(newTransferredCommitmentsCmd(getTemplates))
+
+	return cmd
+}
+
+func newAllTemplatesCmd(getTemplates func() *MailTemplates) *cobra.Command {
+	var flags mailTemplateFlags
+
+	cmd := &cobra.Command{
+		Use:   "all",
+		Short: "Display all mail templates",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			templates := getTemplates()
+			if flags.jsonOutput {
+				return writeJSON(templates)
+			}
+
+			fmt.Println("=== Confirmed Commitments ===")
+			fmt.Println(templates.ConfirmedCommitments)
+
+			fmt.Println("=== Expiring Commitments ===")
+			fmt.Println(templates.ExpiringCommitments)
+
+			fmt.Println("=== Transferred Commitments ===")
+			fmt.Println(templates.TransferredCommitments)
+
+			return nil
+		},
+	}
+
+	doNotSortFlags(cmd)
+	flags.AddToCmd(cmd)
+	return cmd
+}
+
+func newConfirmedCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Command {
+	var flags mailTemplateFlags
+
+	cmd := &cobra.Command{
+		Use:   "confirmed",
+		Short: "Display the confirmed commitments mail template",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return outputTemplate("confirmed_commitments", getTemplates().ConfirmedCommitments, flags.jsonOutput)
+		},
+	}
+
+	doNotSortFlags(cmd)
+	flags.AddToCmd(cmd)
+	return cmd
+}
+
+func newExpiringCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Command {
+	var flags mailTemplateFlags
+
+	cmd := &cobra.Command{
+		Use:   "expiring",
+		Short: "Display the expiring commitments mail template",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return outputTemplate("expiring_commitments", getTemplates().ExpiringCommitments, flags.jsonOutput)
+		},
+	}
+
+	doNotSortFlags(cmd)
+	flags.AddToCmd(cmd)
+	return cmd
+}
+
+func newTransferredCommitmentsCmd(getTemplates func() *MailTemplates) *cobra.Command {
+	var flags mailTemplateFlags
+
+	cmd := &cobra.Command{
+		Use:   "transferred",
+		Short: "Display the transferred commitments mail template",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return outputTemplate("transferred_commitments", getTemplates().TransferredCommitments, flags.jsonOutput)
+		},
+	}
+
+	doNotSortFlags(cmd)
+	flags.AddToCmd(cmd)
+	return cmd
+}
+
+// outputTemplate handles the output of a single template with optional JSON formatting.
+func outputTemplate(name, content string, jsonOutput bool) error {
+	if jsonOutput {
+		output := map[string]string{name: content}
+		return writeJSON(output)
+	}
+	fmt.Println(content)
+	return nil
+}

--- a/internal/cmd/mail_template.go
+++ b/internal/cmd/mail_template.go
@@ -30,7 +30,7 @@ func newMailTemplateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "mail-template",
-		Short: "Display configured mail templates",
+		Short: "Display configured mail templates (cloud-admin only)",
 		Long:  "Display configured mail templates. Can be used to check the validity of the configured templates.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := authWithLimesAdmin(cmd, args); err != nil {


### PR DESCRIPTION
Includes the `mail-template` command which can be used to view the stringified or JSON escaped content of all templates or an individual template.