### PR TITLE
[CHANGELOG.md] Fix keep-a-changelog-action parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The sections should follow the order `Added`, `Changed`, `Fixed`, `Removed`, and
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/sapcc/limesctl/compare/v3.11.0...HEAD)
+## [Unreleased]
 
 ### Added
 


### PR DESCRIPTION
The action's release parser accepts an [Unreleased] heading only as
plain text or a link reference ([Unreleased] + a [Unreleased]: url
definition at the bottom).

Also, the link was outdated anyway.
